### PR TITLE
can we do the redaction?

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/continusec/objecthash
+
+go 1.12
+
+require golang.org/x/text v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/objecthash.go
+++ b/objecthash.go
@@ -248,7 +248,7 @@ func nonce() (string, error) {
 	return hex.EncodeToString(n), nil
 }
 
-func redactableIt(p interface{}) (interface{}, error) {
+func RedactableIt(p interface{}) (interface{}, error) {
 	n, err := nonce()
 	if err != nil {
 		return nil, err
@@ -275,7 +275,7 @@ func redactableDict(p map[string]interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		rv[k], err = redactableIt(c)
+		rv[k], err = RedactableIt(c)
 		if err != nil {
 			return nil, err
 		}
@@ -346,6 +346,18 @@ func unredactableDict(p map[string]interface{}, redPref string) (interface{}, er
 		}
 	}
 	return rv, nil
+}
+
+func RedactWithStdRedaction(i interface{}) (string, error) {
+	return RedactWithRedaction(i, REDACTED_PREFIX)
+}
+
+func RedactWithRedaction(i interface{}, redPref string) (string, error) {
+	redacted, err := ObjectHashWithRedaction(i, redPref)
+	if err != nil {
+		return "", err
+	}
+	return redPref + hex.EncodeToString(redacted), nil
 }
 
 type Filterer map[string]Filterer


### PR DESCRIPTION
Hi - I've been working with the redaction feature of `objecthash`, and I have two feelings:

1) I don't normally want to make the whole thing redactable, but I might have specific parts of an object which I will want to redact.
2) Currently, there is no real functionality to actually redact.  It's not like it's hard or anything, just a question of API suitability for purpose.

I haven't implemented it in this PR, but I have a feeling that, maybe, that the nonces should have some kind of `StdNonce` prefix, so a `[]interface{}` which happens to have two members can be distinguished from a redactable, but not redacted `interface{}`.

Also, I made it a module, since those are now in vogue.

-Jamie